### PR TITLE
Make BOSH_CA_CERT optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ resource_types:
   must be specified via out parameters, as documented below.
 * `client`: *Required.* The username or UAA client ID for the BOSH director.
 * `client_secret`: *Required.* The password or UAA client secret for the BOSH director.
-* `ca_cert`: *Required.* CA certificate used to validate SSL connections to Director and UAA. If omitted, the director's
+* `ca_cert`: *Optional.* CA certificate used to validate SSL connections to Director and UAA. If omitted, the director's
   certificate must be already trusted.
 * `config`: *Required.* Type of config to update, valid values are: `cloud` and `runtime`
 * `name`: *Optional.* Property for named-configs. If omitted, will default to `default`

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -5,9 +5,9 @@ cat > $payload <&0
 target=$(jq -r '.source.target // ""' < $payload)
 client="$(jq -r '.source.client // ""' < $payload)"
 client_secret=$(jq -r '.source.client_secret // ""' < $payload)
-ca_cert=$(jq -r '.source.ca_cert // ""' < $payload)
+ca_cert=$(jq -r '.source.ca_cert // null' < $payload)
 config=$(jq -r '.source.config // ""' < $payload)
-name=$(jq -r '.source.name // ""' < $payload) 
+name=$(jq -r '.source.name // ""' < $payload)
 
 if [ -z "$name" ]; then
   name=default
@@ -34,13 +34,6 @@ then
     exit 1
 fi
 
-if [ -z "$ca_cert" ]
-then
-    echo >&2 "invalid payload (missing source.ca_cert):"
-    cat $payload >&2
-    exit 1
-fi
-
 if [[ "$config" != "cloud" && "$config" != "runtime" ]]
 then
     echo >&2 "invalid payload (source.config should be 'cloud' or 'runtime'):"
@@ -51,7 +44,7 @@ fi
 export BOSH_ENVIRONMENT="${target}"
 export BOSH_CLIENT="${client}"
 export BOSH_CLIENT_SECRET="${client_secret}"
-export BOSH_CA_CERT="${ca_cert}"
+[[ "$ca_cert" != "null" ]] && export BOSH_CA_CERT="${ca_cert}"
 export BOSH_NON_INTERACTIVE=1
 
 calc_reference() {


### PR DESCRIPTION
Allow `ca_cert` to be omitted in source configuration. Useful for environments where CA is already added to a truststore.

Fixes #5