### PR TITLE
Allow dynamic configuration of BOSH Director via `source_file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ resource_types:
 
 ## Source Configuration
 
-* `target`: *Optional.* The address of the BOSH director which will be used for the deployment. If omitted, target_file
-  must be specified via out parameters, as documented below.
+* `target`: *Optional.* The address of the BOSH director which will be used for the deployment. If omitted, `source_file` must be specified via out parameters, as documented below.
 * `client`: *Required.* The username or UAA client ID for the BOSH director.
 * `client_secret`: *Required.* The password or UAA client secret for the BOSH director.
 * `ca_cert`: *Required.* CA certificate used to validate SSL connections to Director and UAA. If omitted, the director's
@@ -40,6 +39,22 @@ resource_types:
     name: my-named-config
 ```
 
+### Dynamic Source Configuration
+
+Sometimes source configuration cannot be known ahead of time, such as when a BOSH director is created as part of your
+pipeline. In these scenarios, it is helpful to be able to have a dynamic source configuration. In addition to the
+normal parameters for `put`, the following parameters can be provided to redefine the source:
+
+* `source_file`: *Optional.* Path to a file containing a YAML or JSON source config. This allows the target to be determined
+  at runtime, e.g. by acquiring a BOSH lite instance using the
+  [Pool resource](https://github.com/concourse/pool-resource). The content of the `source_file` should have the same
+  structure as the source configuration for the resource itself. The `source_file` will be merged into the exist source
+  configuration.
+
+_Notes_:
+ - `target` must **ONLY** be configured via the `source_file` otherwise the implicit `get` will fail after the `put`.
+ - This is only supported for a `put`.
+
 ## Behaviour
 
 ### `in`: Download most recent config from BOSH director
@@ -60,6 +75,14 @@ deployment manifest and then deploy.
 
 * `manifest`: *Required.* Path to a BOSH config manifest file.
 * `releases`: Array of paths to bosh releases to upload
+* `source_file`: *Optional.* Path to a file containing a BOSH director address.
+  This allows the target to be determined at runtime, e.g. by acquiring a BOSH
+  lite instance using the [Pool
+  resource](https://github.com/concourse/pool-resource).
+
+  If both `source_file` and `target` are specified, `source_file` takes
+  precedence.
+
 
 ``` yaml
 # Update config

--- a/assets/check
+++ b/assets/check
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # vim: set ft=sh
 
@@ -8,6 +8,7 @@ exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
+setup_bosh_access
 
 last_ref=$(jq -r '.version.ref // ""' < $payload)
 new_ref="$(calc_reference)"

--- a/assets/check
+++ b/assets/check
@@ -8,6 +8,14 @@ exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
+
+# target not set, just emit input version, as prolly implicit get after put with source_file
+if [ -z "$(jq -r '.source.target // ""' < $payload)" ]; then
+  echo '{"version":{}}' >&3
+  exit 0
+fi
+
+
 setup_bosh_access
 
 last_ref=$(jq -r '.version.ref // ""' < $payload)

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -1,59 +1,87 @@
-payload=$(mktemp $TMPDIR/script-request.XXXXXX)
 
-cat > $payload <&0
+function munge_with_source_file() {
+    source_file=$(jq -r '.params.source_file // ""' < $payload)
+    if [ -n "$source_file" ]
+    then
+        if [ ! -f "$source_file" ]
+        then
+            echo >&2 "source_file was specified ($source_file) but did not exist"
+            cat $payload >&2
+            exit 1
+        else
+            orig_payload="$(mktemp $TMPDIR/script-request.XXXXXX)"
+            mv "$payload" "$orig_payload"
+            jq -s 'add' "$orig_payload" <(jq -s 'add | {source:.}' <(jq '.source' "$orig_payload") <(jq '.' "$source_file")) > "$payload"
+            cat $payload >&2
+        fi
+    fi
+}
 
-target=$(jq -r '.source.target // ""' < $payload)
-client="$(jq -r '.source.client // ""' < $payload)"
-client_secret=$(jq -r '.source.client_secret // ""' < $payload)
-ca_cert=$(jq -r '.source.ca_cert // ""' < $payload)
-config=$(jq -r '.source.config // ""' < $payload)
-name=$(jq -r '.source.name // ""' < $payload) 
+function set_and_validate_vars() {
+    target=$(jq -r '.source.target // ""' < $payload)
+    client="$(jq -r '.source.client // ""' < $payload)"
+    client_secret=$(jq -r '.source.client_secret // ""' < $payload)
+    ca_cert=$(jq -r '.source.ca_cert // ""' < $payload)
+    config=$(jq -r '.source.config // ""' < $payload)
+    name=$(jq -r '.source.name // ""' < $payload)
 
-if [ -z "$name" ]; then
-  name=default
-fi
+    if [ -z "$name" ]; then
+    name=default
+    fi
 
-if [ -z "$target" ]
-then
-    echo >&2 "invalid payload (missing source.target):"
-    cat $payload >&2
-    exit 1
-fi
+    if [ -z "$target" ]
+    then
+        echo >&2 "invalid payload (missing source.target):"
+        cat $payload >&2
+        exit 1
+    fi
 
-if [ -z "$client" ]
-then
-    echo >&2 "invalid payload (missing source.client):"
-    cat $payload >&2
-    exit 1
-fi
+    if [ -z "$client" ]
+    then
+        echo >&2 "invalid payload (missing source.client):"
+        cat $payload >&2
+        exit 1
+    fi
 
-if [ -z "$client_secret" ]
-then
-    echo >&2 "invalid payload (missing source.client_secret):"
-    cat $payload >&2
-    exit 1
-fi
+    if [ -z "$client_secret" ]
+    then
+        echo >&2 "invalid payload (missing source.client_secret):"
+        cat $payload >&2
+        exit 1
+    fi
 
-if [ -z "$ca_cert" ]
-then
-    echo >&2 "invalid payload (missing source.ca_cert):"
-    cat $payload >&2
-    exit 1
-fi
+    if [ -z "$ca_cert" ]
+    then
+        echo >&2 "invalid payload (missing source.ca_cert):"
+        cat $payload >&2
+        exit 1
+    fi
 
-if [[ "$config" != "cloud" && "$config" != "runtime" ]]
-then
-    echo >&2 "invalid payload (source.config should be 'cloud' or 'runtime'):"
-    cat $payload >&2
-    exit 1
-fi
+    if [[ "$config" != "cloud" && "$config" != "runtime" ]]
+    then
+        echo >&2 "invalid payload (source.config should be 'cloud' or 'runtime'):"
+        cat $payload >&2
+        exit 1
+    fi
+}
 
-export BOSH_ENVIRONMENT="${target}"
-export BOSH_CLIENT="${client}"
-export BOSH_CLIENT_SECRET="${client_secret}"
-export BOSH_CA_CERT="${ca_cert}"
-export BOSH_NON_INTERACTIVE=1
+function export_bosh_vars() {
+    export BOSH_ENVIRONMENT="${target}"
+    export BOSH_CLIENT="${client}"
+    export BOSH_CLIENT_SECRET="${client_secret}"
+    export BOSH_CA_CERT="${ca_cert}"
+    export BOSH_NON_INTERACTIVE=1
+}
 
-calc_reference() {
+function calc_reference() {
     bosh config --type="${config}" --name="${name}" | sha1sum | cut -f1 -d' '
 }
+
+function setup_bosh_access() {
+    munge_with_source_file
+    set_and_validate_vars
+    export_bosh_vars
+}
+
+payload=$(mktemp $TMPDIR/script-request.XXXXXX)
+cat > $payload <&0

--- a/assets/in
+++ b/assets/in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # vim: set ft=sh
 
@@ -10,6 +10,14 @@ exec 1>&2 # redirect all output to stderr for logging
 destination=$1
 
 source $(dirname $0)/common.sh
+
+# target not set, just emit input version, as prolly implicit get after put with source_file
+if [ -z "$(jq -r '.source.target // ""' < $payload)" ]; then
+  jq -r '.version | {version:.}' < $payload >&3
+  exit 0
+fi
+
+setup_bosh_access
 
 if [ -z "$destination" ]; then
   echo "usage: $0 <path/to/destination>" >&2

--- a/assets/out
+++ b/assets/out
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # vim: set ft=sh
 
 set -e
@@ -9,6 +9,7 @@ exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
+setup_bosh_access
 
 manifest=$(jq -r '.params.manifest // ""' < "${payload}")
 if [ -z "$manifest" ]


### PR DESCRIPTION
This commit allows the resource to use a `source_file`, just like the [bosh-deployment-resource](https://github.com/cloudfoundry/bosh-deployment-resource). This means that BOSH Director config can be dynamically loaded rather than being configured at `set-pipeline` time, for instance from a pool, or from a Director that is created as part of the pipeline.

It works by taking the contents of `target_file` (if specified, and if present) and munging it over the top of whatever was in the `source` provided to each script.

* I changed the shebang to use Bash, as I needed to use process substitution.
* The `jq` calls can almost certainly be refactored by someone that knows what they're doing (ie, not me)
* I had to refactor the common Bash code, so I could avoid validation of vars on an implicit get.